### PR TITLE
Fix broken Makefile.in to correcty install.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,6 +5,7 @@
 prefix      = @prefix@
 exec_prefix = @exec_prefix@
 srcdir      = @srcdir@
+datarootdir = @datarootdir@
 
 ##############################################################################
 # Compiler and system configuration


### PR DESCRIPTION
Autotools has for quite some time now referenced a datarootdir variable.
Borrowing from the main SWIG development circa June 2006 (in between
releases 1.3.30 and 1.3.31) we simply add this variable to the Makefile.
